### PR TITLE
Iptables service var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,7 +25,6 @@ clients: []
 openvpn_push: []
 manage_firewall_rules: true
 iptables_service: iptables
-iptables_debian_save_command: "/etc/init.d/iptables-persistent save"
 openvpn_client_register_dns: true
 openvpn_use_crl: false
 openvpn_duplicate_cn: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,8 @@ ci_build: false
 clients: []
 openvpn_push: []
 manage_firewall_rules: true
+iptables_service: iptables
+iptables_debian_save_command: "/etc/init.d/iptables-persistent save"
 openvpn_client_register_dns: true
 openvpn_use_crl: false
 openvpn_duplicate_cn: false

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,8 +1,19 @@
-- name: Enable iptables
-  service:
-    name: iptables
-    enabled: true
-    state: started
+- name: setting facts for CentOS/RHEL/Fedora
+  set_fact:
+    iptables_service: iptables
+  when: ansible_os_family == 'RedHat'
+
+- name: setting facts for Debian < 9 or Ubuntu < 16
+  set_fact:
+    iptables_save_cmd: /etc/init.d/iptables-persistent
+    iptables_service: iptables
+  when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int < 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 16)
+
+- name: setting facts for Debian >= 9 or Ubuntu >= 16
+  set_fact:
+    iptables_save_cmd: /usr/sbin/netfilter-persistent
+    iptables_service: netfilter-service
+  when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
 
 - name: iptables - Allow VPN forwarding
   iptables:
@@ -47,5 +58,11 @@
   when: ansible_pkg_mgr == "Debian"
 
 - name: iptables - save everything (Debian/Ubuntu)
-  command: /etc/init.d/iptables-persistent save
+  command: "{{ iptables_save_cmd }} save"
   when: ansible_os_family == 'Debian'
+
+- name: Enable iptables
+  service:
+    name: "{{ iptables_service }}"
+    enabled: true
+    state: started

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,8 +1,14 @@
 - name: Change facts for Debian >= 9 or Ubuntu >= 16
   set_fact:
-    iptables_debian_save_command: "/usr/sbin/netfilter-persistent save"
+    iptables_save_command: "/usr/sbin/netfilter-persistent save"
     iptables_service: netfilter-persistent
   when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
+
+- name: Install iptables-persistent (Debian/Ubuntu)
+  package:
+    name: iptables-persistent
+    state: present
+  when: ansible_pkg_mgr == "Debian"
 
 - name: Enable iptables
   service:
@@ -41,17 +47,6 @@
     jump: SNAT
     comment: "Perform NAT readdressing"
 
-- name: iptables - save everything (CentOS/RHEL/Fedora)
-  shell: iptables-save > /etc/sysconfig/iptables
-  become: yes
-  when: ansible_os_family == 'RedHat'
-
-- name: Install iptables-persistent (Debian/Ubuntu)
-  package:
-    name: iptables-persistent
-    state: present
-  when: ansible_pkg_mgr == "Debian"
-
-- name: iptables - save everything (Debian/Ubuntu)
-  command: "{{ iptables_debian_save_command }}"
-  when: ansible_os_family == 'Debian'
+- name: iptables - save everything (Debian/Ubuntu and CentOS/RHEL/Fedora)
+  command: "{{ iptables_save_command }}"
+  when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,4 +1,4 @@
-- name: Change facts for Debian >= 9 or Ubuntu >= 16
+- name: Change facts to use netfilter-persistent on Debian >= 9 or Ubuntu >= 16
   set_fact:
     iptables_save_command: "/usr/sbin/netfilter-persistent save"
     iptables_service: netfilter-persistent

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -15,6 +15,12 @@
     iptables_service: netfilter-service
   when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
 
+- name: Enable iptables
+  service:
+    name: "{{ iptables_service }}"
+    enabled: true
+    state: started
+
 - name: iptables - Allow VPN forwarding
   iptables:
     chain: FORWARD
@@ -60,9 +66,3 @@
 - name: iptables - save everything (Debian/Ubuntu)
   command: "{{ iptables_save_cmd }} save"
   when: ansible_os_family == 'Debian'
-
-- name: Enable iptables
-  service:
-    name: "{{ iptables_service }}"
-    enabled: true
-    state: started

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,7 +1,7 @@
 - name: Change facts for Debian >= 9 or Ubuntu >= 16
   set_fact:
     iptables_debian_save_command: "/usr/sbin/netfilter-persistent save"
-    iptables_service: netfilter-service
+    iptables_service: netfilter-persistent
   when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
 
 - name: Enable iptables

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,6 +1,6 @@
 - name: Change facts for Debian >= 9 or Ubuntu >= 16
   set_fact:
-    iptables_debian_save_command: /usr/sbin/netfilter-persistent
+    iptables_debian_save_command: "/usr/sbin/netfilter-persistent save"
     iptables_service: netfilter-service
   when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
 

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -8,7 +8,7 @@
   package:
     name: iptables-persistent
     state: present
-  when: ansible_pkg_mgr == "Debian"
+  when: ansible_os_family == "Debian"
 
 - name: Enable iptables
   service:

--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -1,17 +1,6 @@
-- name: setting facts for CentOS/RHEL/Fedora
+- name: Change facts for Debian >= 9 or Ubuntu >= 16
   set_fact:
-    iptables_service: iptables
-  when: ansible_os_family == 'RedHat'
-
-- name: setting facts for Debian < 9 or Ubuntu < 16
-  set_fact:
-    iptables_save_cmd: /etc/init.d/iptables-persistent
-    iptables_service: iptables
-  when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int < 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 16)
-
-- name: setting facts for Debian >= 9 or Ubuntu >= 16
-  set_fact:
-    iptables_save_cmd: /usr/sbin/netfilter-persistent
+    iptables_debian_save_command: /usr/sbin/netfilter-persistent
     iptables_service: netfilter-service
   when: (ansible_distribution == 'Debian' and ansible_lsb.major_release|int >= 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int >= 16)
 
@@ -64,5 +53,5 @@
   when: ansible_pkg_mgr == "Debian"
 
 - name: iptables - save everything (Debian/Ubuntu)
-  command: "{{ iptables_save_cmd }} save"
+  command: "{{ iptables_debian_save_command }}"
   when: ansible_os_family == 'Debian'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,1 @@
+iptables_save_command: "/etc/init.d/iptables-persistent save"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,1 @@
+iptables_save_command: "iptables-save > /etc/sysconfig/iptables"


### PR DESCRIPTION
This fixes some breakage in the iptables steps on Debian 9+/Ubuntu 16+. After these fixes I get a clean install on my Debian 9.1 stretch instance.

1. Make a variable 'iptables_save_command' that is os-specific (vars/RedHat.yml and vars/Debian.yml).
2. Add default variable 'iptables_service' in defaults/main.yml.
3. Add override logic for 'iptables_service' and 'iptables_save_command' in tasks/iptables.yml to support the 'netfilter-persistent' service renaming in Debian 9+ and Ubuntu 16+.
4. Make sure the iptables-persistent package install happens before the service is enabled.
5. Use 'ansible_os_family' instead of 'ansible_pkg_mgr' to detect Debian OS in the iptables-persistent package install step. 'ansible_pkg_mgr' is failing to recognise Debian on my Debian stretch host.
6. Make the saving of iptables rules a single step with a variable.